### PR TITLE
注解可省略参数

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "handlebars": "^4.7.8",
     "json5": "^2.2.3",
-    "typescript": "^5.5.3"
+    "ohos-typescript": "^4.9.5-r6"
   }
 }

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -202,6 +202,9 @@ class Analyzer {
                     const result = this.resolveDecoration(item)
                     if (isNotEmpty(result.name)) this.result = result
                 }
+                if (item.kind === ts.SyntaxKind.DefaultKeyword) {
+                    this.result.isDefaultExport = true
+                }
             })
             if (AnnotationMgr.isRouteAnnotation(this.result.annotation)){
                 // 解析路由注解

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -3,13 +3,13 @@
  * @date: 2024/12/5
  * @desc:
  */
-import ts, {isClassDeclaration, isIdentifier} from "typescript";
+import ts, { isClassDeclaration, isIdentifier, isStructDeclaration } from "ohos-typescript";
 
 export default class NodeHelper {
 
     static getClassName(node: ts.Node) {
         let className = ""
-        if (isClassDeclaration(node)){
+        if (isClassDeclaration(node) || isStructDeclaration(node)) {
             if (node.name && isIdentifier(node.name)) {
                 className = node.name.escapedText ?? ""
             }


### PR DESCRIPTION
该PR包含两部分改动：
1. 使用``ohos-typescript``解析语法树，以正确识别struct声明语法
2. ``@Route``等注解可省略参数，没有指定name的话默认使用struct名称

例如以下三种语法都可生成name为SplashPage的路由：
```ts
@Route
@Component
export struct SplashPage {}
```
```ts
@Route()
@Component
export struct SplashPage {}
```
```ts
@Route({})
@Component
export struct SplashPage {}
```